### PR TITLE
quick fix for exporting bibtex

### DIFF
--- a/scholar.py
+++ b/scholar.py
@@ -1142,7 +1142,7 @@ def csv(querier, header=False, sep='|'):
 def citation_export(querier):
     articles = querier.articles
     for art in articles:
-        print(art.as_citation() + '\n')
+        print(str(art.as_citation())[2:-1].replace("\\n"," ") + '\n')
 
 
 def main():


### PR DESCRIPTION
This fixes a problem of bibtex not working on macOS python 3.6. Error was:
    Traceback (most recent call last):
      File "scholar.py", line 1310, in <module>
        sys.exit(main())
      File "scholar.py", line 1300, in main
        citation_export(querier)
      File "scholar.py", line 1145, in citation_export
        print( (art.as_citation()) + '\n')
    TypeError: can't concat bytes to str